### PR TITLE
Fix content behind Panel not receiving gestures when Panel put inside Stack

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -1113,19 +1113,25 @@ class _SlidingPanelState extends State<SlidingPanel> with TickerProviderStateMix
             _applyPaddings();
           }
 
-          // Wrap with material, so that panel content can use it
-          return Material(
-            type: MaterialType.transparency,
-            // Remove padding, as it is handled by useSafeConfig
-            child: MediaQuery.removePadding(
-              context: context,
-              removeTop: (isModal),
-              removeBottom: (isModal),
-              removeLeft: (isModal),
-              removeRight: (isModal),
-              child: _body,
-            ),
-          );
+          if (isModal) {
+            // Wrap with material, so that panel content can use it
+            // This is needed for modal panels only
+            // If applied to normal panels, the content wouldn't receive
+            // gestures, if the panel is put in [Stack].
+            return Material(
+              type: MaterialType.transparency,
+              child: MediaQuery.removePadding(
+                context: context,
+                removeTop: true,
+                removeBottom: true,
+                removeLeft: true,
+                removeRight: true,
+                child: _body,
+              ),
+            );
+          }
+
+          return _body;
         },
       ),
     );


### PR DESCRIPTION
As the _body was encapsulated in Material Widget, The empty Container should draw a fullscreen view. It should forbid all the event blow it.
