### PR TITLE
Add Scroll Physics option

### DIFF
--- a/lib/src/panel.dart
+++ b/lib/src/panel.dart
@@ -939,6 +939,7 @@ class _SlidingPanelState extends State<SlidingPanel> with TickerProviderStateMix
           child: Material(
             type: MaterialType.transparency,
             child: CustomScrollView(
+              physics: widget.physics,
               controller: _scrollController,
               slivers: <Widget>[
                 // header

--- a/lib/src/panel_modal.dart
+++ b/lib/src/panel_modal.dart
@@ -103,6 +103,7 @@ Future<T> showModalSlidingPanel<T>(
             snapping: _panel.snapping,
             snappingTriggerPercentage: _panel.snappingTriggerPercentage,
             isDraggable: _panel.isDraggable,
+            physics: _panel.physics,
             dragMultiplier: _panel.dragMultiplier,
             duration: _panel.duration,
             curve: _panel.curve,

--- a/lib/src/panel_widget.dart
+++ b/lib/src/panel_widget.dart
@@ -127,10 +127,10 @@ class SlidingPanel extends StatefulWidget {
   /// Default : true
   final bool isDraggable;
 
-  /// The scroll physics that determine how
+  /// The scroll physics that determines how
   /// the scroll view should respond to user input.
   ///
-  /// Default: Platform Convention
+  /// Default: platform convention
   final ScrollPhysics physics;
 
   /// Specify the amount of [PanelContent.bodyContent]

--- a/lib/src/panel_widget.dart
+++ b/lib/src/panel_widget.dart
@@ -127,6 +127,12 @@ class SlidingPanel extends StatefulWidget {
   /// Default : true
   final bool isDraggable;
 
+  /// The scroll physics that determine how
+  /// the scroll view should respond to user input.
+  ///
+  /// Default: Platform Convention
+  final ScrollPhysics physics;
+
   /// Specify the amount of [PanelContent.bodyContent]
   /// to slide up when panel slides.
   ///
@@ -305,6 +311,7 @@ class SlidingPanel extends StatefulWidget {
     this.snapping = PanelSnapping.disabled,
     this.snappingTriggerPercentage = 0.0,
     this.isDraggable = true,
+    this.physics,
     this.parallaxSlideAmount = 0.2,
     this.dragMultiplier = 1.0,
     this.duration = const Duration(milliseconds: 1000),
@@ -341,6 +348,7 @@ class SlidingPanel extends StatefulWidget {
     this.snapping = PanelSnapping.disabled,
     this.snappingTriggerPercentage = 0.0,
     this.isDraggable = true,
+    this.physics,
     this.dragMultiplier = 1.0,
     this.duration = const Duration(milliseconds: 1000),
     this.curve = Curves.fastOutSlowIn,


### PR DESCRIPTION
Hi,

This simple PR allows users to configure custom ScrollPhysics behavior. If null, the panel will work just like before (defaults to platform convention).

The documentation is inspired by ListView's physics documentation;
physics → ScrollPhysics
How the scroll view should respond to user input. [...]

Tested several physics on Android: 
- BouncingScrollPhysics works properly;
- NeverScrollableScrollPhysics basically disables dragging.